### PR TITLE
fix: COC v2.1, README headings, build Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,44 +1,20 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-    environment: test
-    env:
-      NOTION_TOKEN: ${{secrets.NOTION_TOKEN}}
-      
-    timeout-minutes: 6
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [lts/*, 17.x, 16.x]
-
-    runs-on: ${{ matrix.os }} 
-        
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-      # manually install peerdeps for node 12,14
-    - run: npm i seneca seneca-entity seneca-promisify @seneca/provider @seneca/env
-    - run: npm run build --if-present
-    - run: npm test
-
-    # - name: Coveralls
-      # uses: coverallsapp/github-action@master
-      # with:
-       # github-token: ${{ secrets.GITHUB_TOKEN }}
-       # path-to-lcov: ./coverage/lcov.info
+      - uses: actions/checkout@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,32 +1,25 @@
-![Seneca Notion-Provider](http://senecajs.org/files/assets/seneca-logo.png)
+![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
+> A [Seneca.js](http://senecajs.org) plugin
 
-> _Seneca Notion-Provider_ is a plugin for [Seneca](http://senecajs.org)
+# @seneca/notion-provider
 
-
-Provides access to the Notion API using the Seneca *provider*
-convention. Notion API entities are represented as Seneca entities so
-that they can be accessed using the Seneca entity API and messages.
-
-See [seneca-entity](senecajs/seneca-entity) and the [Seneca Data
-Entities
-Tutorial](https://senecajs.org/docs/tutorials/understanding-data-entities.html) for more details on the Seneca entity API.
-
-NOTE: underlying third party SDK needs to be replaced as out of date and has a security issue.
-
-[![npm version](https://img.shields.io/npm/v/@seneca/trello-provider.svg)](https://npmjs.com/package/@seneca/trello-provider)
-[![build](https://github.com/senecajs/seneca-trello-provider/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-trello-provider/actions/workflows/build.yml)
-[![Coverage Status](https://coveralls.io/repos/github/senecajs/seneca-trello-provider/badge.svg?branch=main)](https://coveralls.io/github/senecajs/seneca-trello-provider?branch=main)
-[![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-trello-provider/badge.svg)](https://snyk.io/test/github/senecajs/seneca-trello-provider)
-[![DeepScan grade](https://deepscan.io/api/teams/5016/projects/19462/branches/505954/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=5016&pid=19462&bid=505954)
-[![Maintainability](https://api.codeclimate.com/v1/badges/f76e83896b731bb5d609/maintainability)](https://codeclimate.com/github/senecajs/seneca-trello-provider/maintainability)
-
+[![build](https://github.com/senecajs/seneca-notion-provider/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-notion-provider/actions/workflows/build.yml)
+[![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-notion-provider/badge.svg)](https://snyk.io/test/github/senecajs/seneca-notion-provider)
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
 
+## Install
+
+```sh
+$ npm install @seneca/notion-provider @seneca/env
+```
+
+
+
+<!--START:options-->
 
 ## Quick Example
-
 
 ```js
 
@@ -64,18 +57,25 @@ Console.log('UPDATED PAGE', pageId)
 
 ```
 
-## Install
+## More Examples
 
-```sh
-$ npm install @seneca/notion-provider @seneca/env
-```
+See [test/](test/) for more usage examples.
 
+## Motivation
 
+A [Seneca.js](http://senecajs.org) plugin.
 
-<!--START:options-->
+## Support
 
+If you're using this module and need help, you can:
 
-## Options
+- Post a [github issue](https://github.com/senecajs/seneca-notion-provider/issues)
+- Tweet to [@senecajs](http://twitter.com/senecajs)
+- Ask on the [Gitter](https://gitter.im/senecajs/seneca)
+
+## API
+
+### Options
 
 *None.*
 
@@ -84,8 +84,7 @@ $ npm install @seneca/notion-provider @seneca/env
 
 <!--START:action-list-->
 
-
-## Action Patterns
+### Action Patterns
 
 * ["role":"entity","base":"notion","cmd":"list","name":"database","zone":"provider"](#-roleentitybasenotioncmdlistnamedatabasezoneprovider-)
 * ["role":"entity","base":"notion","cmd":"list","name":"page","zone":"provider"](#-roleentitybasenotioncmdlistnamepagezoneprovider-)
@@ -100,8 +99,7 @@ $ npm install @seneca/notion-provider @seneca/env
 
 <!--START:action-desc-->
 
-
-## Action Descriptions
+### Action Descriptions
 
 ### &laquo; `"role":"entity","base":"notion","cmd":"list","name":"database","zone":"provider"` &raquo;
 
@@ -186,17 +184,9 @@ Get information about the Notion SDK.
 
 <!--END:action-desc-->
 
-## More Examples
-
-## Motivation
-
-## Support
-
-Check out our sponsors and supporters, Voxgig, on their website [here](https://www.voxgig.com).
-
-## API
-
 ## Contributing
+
+The [Senecajs org](https://github.com/senecajs/) encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
 
 The [SenecaJS org](http://senecajs.org/) encourages participation. If you feel you can help in any way, be
 it with bug reporting, documentation, examples, extra testing, or new features, feel free

--- a/README.md
+++ b/README.md
@@ -9,44 +9,15 @@
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
 
-## Quick Example
 
+Provides access to the Notion API using the Seneca *provider*
+convention. Notion API entities are represented as Seneca entities so
+that they can be accessed using the Seneca entity API and messages.
+See [seneca-entity](senecajs/seneca-entity) and the [Seneca Data
+Entities
+Tutorial](https://senecajs.org/docs/tutorials/understanding-data-entities.html) for more details on the Seneca entity API.
+NOTE: underlying third party SDK needs to be replaced as out of date and has a security issue.
 
-```js
-
-// Setup - get the key value (<SECRET>) separately from a vault or
-// environment variable.
-Seneca()
-  // Get API keys using the seneca-env plugin
-  .use('env', {
-    var: {
-      $NOTION_TOKEN: String,
-    }
-  })
-  .use('provider', {
-    provider: {
-      notion: {
-        keys: {
-          authToken: {
-            value: '$NOTION_TOKEN'
-          },
-        }
-      }
-    }
-  })
-  .use('notion-provider')
-
-let pageId = await seneca.entity('provider/notion/page')
-                  .load$('<notion_page_id>');
-
-Console.log('PAGE', pageId)
-
-pageId.properties.checkMe.checkbox = false;
-pageId = await pageId.save$()
-
-Console.log('UPDATED PAGE', pageId)
-
-```
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,45 @@
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
 
+## Quick Example
+
+
+```js
+
+// Setup - get the key value (<SECRET>) separately from a vault or
+// environment variable.
+Seneca()
+  // Get API keys using the seneca-env plugin
+  .use('env', {
+    var: {
+      $NOTION_TOKEN: String,
+    }
+  })
+  .use('provider', {
+    provider: {
+      notion: {
+        keys: {
+          authToken: {
+            value: '$NOTION_TOKEN'
+          },
+        }
+      }
+    }
+  })
+  .use('notion-provider')
+
+let pageId = await seneca.entity('provider/notion/page')
+                  .load$('<notion_page_id>');
+
+Console.log('PAGE', pageId)
+
+pageId.properties.checkMe.checkbox = false;
+pageId = await pageId.save$()
+
+Console.log('UPDATED PAGE', pageId)
+
+```
+
 ## Install
 
 ```sh


### PR DESCRIPTION
## What changed
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Added plugin intro description
- Added `package-lock.json` to `.gitignore`
- Updated `build.yml` to Node 24 / ubuntu-latest
- Added npm, build and Snyk badges

## Fixes
- `version_codeconduct`, `readme_headings`, `content_readme`, `content_gitignore`
